### PR TITLE
Рефакторинг: розділив скрипти, стилі та шаблони

### DIFF
--- a/backend/games_testing/get-games.php
+++ b/backend/games_testing/get-games.php
@@ -60,6 +60,6 @@ function handleRequest() {
     }
 }
 
-// Запустити обробку запиту
+
 handleRequest();
 ?>

--- a/backend/helpers.php
+++ b/backend/helpers.php
@@ -1,0 +1,37 @@
+<?php
+
+
+session_start();
+error_reporting(E_ALL);
+ini_set('display_errors', 1);
+
+function safeRedirect(string $url): void {
+    if (!headers_sent()) {
+        header("Location: $url");
+        exit;
+    }
+    echo "<script>window.location.href = " . json_encode($url) . "</script>";
+    exit;
+}
+
+function formatProductPrice($price): string {
+    return number_format(max(0, floatval($price)), 2, '.', ' ');
+}
+
+function getProductAvailabilityClass(int $stock): string {
+    if ($stock > 10)   return 'text-success';
+    if ($stock > 0)    return 'text-warning';
+    return 'text-danger';
+}
+
+function renderProductBadges(array $product): string {
+    $badges = [];
+    if (!empty($product['is_new'])) {
+        $badges[] = '<span class="badge bg-success me-2">Новинка</span>';
+    }
+    if (!empty($product['discount'])) {
+        $badges[] = '<span class="badge bg-danger me-2">-' 
+            . intval($product['discount']) . '%</span>';
+    }
+    return implode('', $badges);
+}

--- a/backend/products/product.php
+++ b/backend/products/product.php
@@ -1,349 +1,37 @@
 <?php
-error_reporting(E_ALL);
-ini_set('display_errors', 1);
+// public/product.php
 
-session_start();
-
-function safeRedirect($url) {
-    if (!headers_sent()) {
-        header("Location: $url");
-        exit;
-    } else {
-        echo "<script>window.location.href = '$url';</script>";
-        exit;
-    }
-}
-
-function formatProductPrice($price) {
-    return number_format(max(0, floatval($price)), 2, '.', ' ');
-}
-
-function getProductAvailabilityClass($stock) {
-    if ($stock > 10) return 'text-success';
-    if ($stock > 0) return 'text-warning';
-    return 'text-danger';
-}
-
-function renderProductBadges($product) {
-    $badges = [];
-    if (isset($product['is_new']) && $product['is_new']) {
-        $badges[] = '<span class="badge bg-success me-2">Новинка</span>';
-    }
-    if (isset($product['discount']) && $product['discount'] > 0) {
-        $badges[] = '<span class="badge bg-danger me-2">-' . $product['discount'] . '%</span>';
-    }
-    return implode('', $badges);
-}
+require_once __DIR__ . '/../helpers.php';
+require_once __DIR__ . '/../database/Database.php';
 
 try {
-    require_once '../../backend/database/Database.php';
-
-    $db = new Database();
-
-    $pdo = $db->getConnection();
-
-    if (!isset($_SESSION['cart'])) {
-        $_SESSION['cart'] = [];
-    }
+    $db   = new Database();
+    $pdo  = $db->getConnection();
 
     if (!isset($_GET['id'])) {
         throw new Exception('Не передано ідентифікатор товару');
     }
-
     $product_id = filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT);
-    if ($product_id === false || $product_id === null) {
+    if (!$product_id) {
         throw new Exception('Некоректний ідентифікатор товару');
     }
 
-    try {
-        $stmt = $pdo->prepare("SELECT * FROM products WHERE id = ?");
-        $stmt->execute([$product_id]);
-        $product = $stmt->fetch(PDO::FETCH_ASSOC);
-
-        if (!$product) {
-            throw new Exception('Товар не знайдений');
-        }
-    } catch (PDOException $e) {
-        error_log('Помилка бази даних: ' . $e->getMessage());
-        throw new Exception('Не вдалося отримати дані про товар');
+    $stmt = $pdo->prepare("SELECT * FROM products WHERE id = ?");
+    $stmt->execute([$product_id]);
+    $product = $stmt->fetch(PDO::FETCH_ASSOC);
+    if (!$product) {
+        throw new Exception('Товар не знайдений');
     }
+
+    // обробка зображень
+    $images    = array_filter(array_map('trim', explode("\n", $product['image'])));
+    $mainImage = $images[0] ?? '/public/assets/img/placeholder.png';
+
+    // передаємо в шаблон
+    require __DIR__ . '/../views/product_view.php';
+
 } catch (Exception $e) {
-    error_log('Помилка на сторінці товару: ' . $e->getMessage());
-
+    error_log('Product page error: ' . $e->getMessage());
     $_SESSION['error_message'] = $e->getMessage();
-
-    safeRedirect('../../index.php');
+    safeRedirect('/index.php');
 }
-?>
-
-<!DOCTYPE html>
-<html lang="uk">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title><?php echo htmlspecialchars($product['name']); ?> - Ноутбук-Маркет</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link href="../../public/assets/css/style.css" rel="stylesheet">
-    <link href="../../public/assets/css/gallery.css" rel="stylesheet">
-    <style>
-        .image-thumbnails img {
-            transition: all 0.3s ease;
-        }
-        .image-thumbnails img:hover {
-            opacity: 0.7;
-            transform: scale(1.05);
-        }
-        .image-zoom-container {
-            position: fixed;
-            top: 50%;
-            right: 20px;
-            transform: translateY(-50%);
-            width: 300px;
-            height: 300px;
-            background-size: cover;
-            background-position: center;
-            background-repeat: no-repeat;
-            border: 2px solid #007bff;
-            border-radius: 10px;
-            box-shadow: 0 4px 6px rgba(0,0,0,0.1);
-            opacity: 0;
-            transition: opacity 0.3s ease;
-            z-index: 1000;
-            pointer-events: none;
-        }
-        .main-product-image,
-        .image-thumbnails img {
-            cursor: zoom-in;
-        }
-    </style>
-</head>
-<body>
-
-<?php if (isset($_SESSION['error_message'])): ?>
-    <div class="alert alert-danger alert-dismissible fade show" role="alert">
-        <?php
-        echo htmlspecialchars($_SESSION['error_message']);
-        unset($_SESSION['error_message']);
-        ?>
-        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-    </div>
-<?php endif; ?>
-
-<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
-    <div class="container">
-        <a class="navbar-brand" href="../../index.php">Ноутбук-Маркет</a>
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
-            <span class="navbar-toggler-icon"></span>
-        </button>
-        <div class="collapse navbar-collapse" id="navbarNav">
-            <ul class="navbar-nav me-auto">
-                <li class="nav-item">
-                    <a class="nav-link" href="../../index.php">Головна</a>
-                </li>
-            </ul>
-            <ul class="navbar-nav">
-                <li class="nav-item">
-                    <a class="nav-link" href="../orders/cart.php">
-                        Кошик
-                        <span class="badge bg-primary">
-                            <?php echo count($_SESSION['cart']); ?>
-                        </span>
-                    </a>
-                </li>
-            </ul>
-        </div>
-    </div>
-</nav>
-
-<div class="container my-5">
-    <?php try { ?>
-        <?php
-        try {
-            $images = explode("\n", $product['image']);
-            $mainImage = trim($images[0]);
-
-            if (empty($mainImage)) {
-                throw new Exception('Зображення товару відсутнє');
-            }
-
-            $allImages = htmlspecialchars(json_encode(array_map('trim', $images)));
-        } catch (Exception $e) {
-            error_log('Помилка обробки зображень: ' . $e->getMessage());
-            $mainImage = '../../public/assets/img/placeholder.png';
-            $allImages = '[]';
-        }
-        ?>
-
-        <div class="row">
-            <div class="col-md-6">
-                <div class="gallery-slider position-relative">
-                    <img src="<?php echo htmlspecialchars($mainImage); ?>"
-                         class="img-fluid rounded main-product-image"
-                         alt="<?php echo htmlspecialchars($product['name']); ?>">
-
-                    <?php if (count($images) > 1): ?>
-                        <div class="image-thumbnails mt-3 d-flex">
-                            <?php foreach ($images as $img): ?>
-                                <img src="<?php echo htmlspecialchars(trim($img)); ?>"
-                                     class="img-thumbnail me-2"
-                                     style="max-width: 80px; cursor: pointer;"
-                                     onclick="changeMainImage(this)">
-                            <?php endforeach; ?>
-                        </div>
-                    <?php endif; ?>
-                </div>
-            </div>
-            <div class="col-md-6">
-                <div class="product-header mb-4">
-                    <?php echo renderProductBadges($product); ?>
-                    <h1><?php echo htmlspecialchars($product['name']); ?></h1>
-                </div>
-
-                <p class="text-primary fs-3 fw-bold">
-                    <?php echo formatProductPrice($product['price']); ?> грн
-                </p>
-
-                <div class="product-meta mb-4">
-                    <p><?php echo htmlspecialchars($product['description'] ?? 'Опис відсутній'); ?></p>
-
-                    <div class="stock-info">
-                        <p class="<?php echo getProductAvailabilityClass($product['stock'] ?? 0); ?>">
-                            <?php
-                            if (isset($product['stock']) && $product['stock'] > 0) {
-                                echo "В наявності: " . intval($product['stock']) . " шт.";
-                            } else {
-                                echo "Немає в наявності";
-                            }
-                            ?>
-                        </p>
-                    </div>
-                </div>
-
-                <div class="product-actions">
-                    <?php if (isset($product['stock']) && $product['stock'] > 0): ?>
-                        <form action="../orders/cart.php" method="get">
-                            <input type="hidden" name="action" value="add">
-                            <input type="hidden" name="id" value="<?php echo $product['id']; ?>">
-
-                            <div class="quantity-selector mb-3">
-                                <label for="quantity" class="form-label">Кількість:</label>
-                                <div class="input-group">
-                                    <button class="btn btn-outline-secondary" type="button" onclick="changeQuantity(-1)">-</button>
-                                    <input type="number"
-                                           class="form-control text-center"
-                                           id="quantity"
-                                           name="quantity"
-                                           value="1"
-                                           min="1"
-                                           max="<?php echo $product['stock']; ?>">
-                                    <button class="btn btn-outline-secondary" type="button" onclick="changeQuantity(1)">+</button>
-                                </div>
-                            </div>
-
-                            <div class="d-grid gap-2">
-                                <button type="submit" class="btn btn-primary btn-lg">
-                                    Додати в кошик
-                                </button>
-                                <a href="../../index.php" class="btn btn-outline-secondary">Повернутися до списку товарів</a>
-                            </div>
-                        </form>
-                    <?php else: ?>
-                        <div class="d-grid gap-2">
-                            <button class="btn btn-secondary btn-lg" disabled>Немає в наявності</button>
-                            <a href="../../index.php" class="btn btn-outline-secondary">Повернутися до списку товарів</a>
-                        </div>
-                    <?php endif; ?>
-                </div>
-            </div>
-        </div>
-
-        <div class="row mt-5">
-            <div class="col-12">
-                <div class="card shadow-lg border-0 rounded-lg">
-                    <div class="card-header bg-gradient-primary py-3">
-                        <h3 class="card-title text-white mb-0 font-weight-bold">
-                            <i class="fas fa-info-circle mr-2"></i>Детальний опис
-                        </h3>
-                    </div>
-                    <div class="card-body p-4">
-                        <?php
-                        $full_description = $product['full_description'] ?? 'Детальний опис відсутній';
-                        ?>
-                        <div class="description-container">
-                            <p class="card-text text-dark description-text" style="
-                        font-size: 1.1rem;
-                        line-height: 1.8;
-                        letter-spacing: 0.03em;
-                        text-align: justify;
-                        font-family: 'Arial', 'Helvetica Neue', sans-serif;
-                        color: #333;
-                        background-color: #f8f9fa;
-                        border-left: 4px solid #007bff;
-                        padding: 20px;
-                        border-radius: 8px;
-                        box-shadow: 0 4px 6px rgba(0,0,0,0.1);
-                    ">
-                                <?php echo nl2br(htmlspecialchars($full_description)); ?>
-                            </p>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-        <?php
-    } catch (Exception $e) {
-        error_log('Помилка рендерингу сторінки товару: ' . $e->getMessage());
-        ?>
-        <div class="alert alert-danger alert-dismissible fade show shadow" role="alert">
-            <strong><i class="fas fa-exclamation-triangle mr-2"></i>Технічна проблема!</strong>
-            Виникла помилка при відображенні сторінки товару.
-            <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-                <span aria-hidden="true">&times;</span>
-            </button>
-        </div>
-    <?php } ?>
-
-    <style>
-        .bg-gradient-primary {
-            background: linear-gradient(to right, #007bff, #0056b3);
-        }
-    </style>
-</div>
-
-<footer class="bg-dark text-white py-4 mt-5">
-    <div class="container">
-        <div class="row">
-            <div class="col-md-6">
-                <h5>Ноутбук-Маркет</h5>
-                <p>Найкращі ноутбуки за найкращими цінами</p>
-            </div>
-            <div class="col-md-6 text-md-end">
-                <p>&copy; 2025 Ноутбук-Маркет. Всі права захищені.</p>
-            </div>
-        </div>
-    </div>
-</footer>
-
-<div class="image-zoom-container"></div>
-
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-<script type="module" src="../../public/assets/js/main.js"></script>
-
-<script>
-    function changeMainImage(thumbnail) {
-        const mainImage = document.querySelector('.main-product-image');
-        mainImage.src = thumbnail.src;
-    }
-
-    function changeQuantity(delta) {
-        const quantityInput = document.getElementById('quantity');
-        let currentValue = parseInt(quantityInput.value);
-        let newValue = currentValue + delta;
-
-        if (newValue >= parseInt(quantityInput.min) && newValue <= parseInt(quantityInput.max)) {
-            quantityInput.value = newValue;
-        }
-    }
-</script>
-</body>
-</html>

--- a/backend/utils/compare.php
+++ b/backend/utils/compare.php
@@ -1,212 +1,42 @@
 <?php
 error_reporting(E_ALL);
 ini_set('display_errors', 1);
-
 session_start();
+require_once __DIR__ . '/../database/Database.php';
 
 try {
-    require_once '../../backend/database/Database.php';
-
     $db = new Database();
-
     $pdo = $db->getConnection();
 
-    $product_ids = isset($_GET['products']) ? explode(',', $_GET['products']) : [];
-    $product_ids = array_map(function($id) {
-        $sanitized_id = filter_var($id, FILTER_VALIDATE_INT);
-        if ($sanitized_id === false) {
-            throw new Exception('Некоректний ідентифікатор товару');
-        }
-        return $sanitized_id;
-    }, $product_ids);
 
-    $products = [];
-    if (!empty($product_ids)) {
-        try {
-            $placeholders = implode(',', array_fill(0, count($product_ids), '?'));
-            $stmt = $pdo->prepare("
-                SELECT p.*, 
-                (SELECT image_filename FROM product_images WHERE product_id = p.id LIMIT 1) as image_filename 
-                FROM products p 
-                WHERE id IN ($placeholders)
-            ");
-            $stmt->execute($product_ids);
-            $products = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    $idsParam = $_GET['products'] ?? '';
+    $ids = $idsParam === '' ? [] : explode(',', $idsParam);
+    $ids = array_map('intval', $ids);
 
-            if ($stmt->rowCount() === 0) {
-                throw new Exception('Товари не знайдені');
-            }
-        } catch (PDOException $e) {
-            error_log('Помилка бази даних: ' . $e->getMessage());
-            throw new Exception('Не вдалося отримати дані про товари');
+    if (empty($ids)) {
+        $products = [];
+    } else {
+        $placeholders = implode(',', array_fill(0, count($ids), '?'));
+        $sql = "
+            SELECT p.*,
+                   (SELECT image_filename FROM product_images WHERE product_id = p.id LIMIT 1) AS image_filename
+            FROM products p
+            WHERE p.id IN ($placeholders)
+        ";
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute($ids);
+        $products = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        if ($stmt->rowCount() === 0) {
+            throw new Exception('Товари не знайдені');
         }
     }
+
+    $error = null;
 } catch (Exception $e) {
-    error_log('Помилка в скрипті порівняння: ' . $e->getMessage());
-
-    $error_message = $e->getMessage();
+    error_log("Compare error: {$e->getMessage()}");
+    $products = [];
+    $error = $e->getMessage();
 }
-?>
-<!DOCTYPE html>
-<html lang="uk">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Порівняння товарів</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.0/font/bootstrap-icons.css" rel="stylesheet">
-    <style>
-        .table-compare th, .table-compare td {
-            vertical-align: middle;
-            text-align: center;
-        }
-        .table-compare thead th {
-            background-color: #f8f9fa;
-        }
-    </style>
-</head>
-<body>
-<div class="container-fluid mt-5">
-    <h1 class="mb-4 text-center">Порівняння ноутбуків</h1>
 
-    <?php if (isset($error_message)): ?>
-        <div class="alert alert-danger">
-            <?php echo htmlspecialchars($error_message); ?>
-            <p>Виникла технічна проблема. Будь ласка, спробуйте пізніше або зв'яжіться з підтримкою.</p>
-        </div>
-    <?php elseif (empty($products)): ?>
-        <div class="alert alert-info">Немає товарів для порівняння</div>
-    <?php else: ?>
-        <div class="table-responsive">
-            <table class="table table-bordered table-striped table-hover table-compare">
-                <thead>
-                <tr>
-                    <th>Параметр</th>
-                    <?php foreach ($products as $product): ?>
-                        <th>
-                            <?php echo htmlspecialchars($product['name']); ?>
-                            <button class="btn btn-sm btn-danger remove-compare" data-product-id="<?php echo $product['id']; ?>">
-                                <i class="bi bi-trash"></i>
-                            </button>
-                        </th>
-                    <?php endforeach; ?>
-                </tr>
-                <tr>
-                    <th>Зображення</th>
-                    <?php foreach ($products as $product): ?>
-                        <th>
-                            <?php if (!empty($product['image_filename'])): ?>
-                                <img src="<?php echo htmlspecialchars($product['image_filename']); ?>"
-                                     alt="<?php echo htmlspecialchars($product['name']); ?>"
-                                     class="img-fluid" style="max-height: 200px;">
-                            <?php else: ?>
-                                <p>Зображення відсутнє</p>
-                            <?php endif; ?>
-                        </th>
-                    <?php endforeach; ?>
-                </tr>
-                </thead>
-                <tbody>
-                <!-- Basic Information -->
-                <tr>
-                    <td class="fw-bold">Ціна</td>
-                    <?php foreach ($products as $product): ?>
-                        <td><?php echo number_format($product['price'], 2, '.', ' '); ?> грн</td>
-                    <?php endforeach; ?>
-                </tr>
-                <tr>
-                    <td class="fw-bold">Опис</td>
-                    <?php foreach ($products as $product): ?>
-                        <td><?php echo !empty($product['description']) ? htmlspecialchars($product['description']) : 'Опис відсутній'; ?></td>
-                    <?php endforeach; ?>
-                </tr>
-
-                <!-- Technical Specifications -->
-                <tr>
-                    <td class="fw-bold">Екран</td>
-                    <?php foreach ($products as $product): ?>
-                        <td><?php echo htmlspecialchars($product['screen_size']); ?> дюймів</td>
-                    <?php endforeach; ?>
-                </tr>
-                <tr>
-                    <td class="fw-bold">Відеокарта</td>
-                    <?php foreach ($products as $product): ?>
-                        <td><?php echo htmlspecialchars($product['video_card_type']); ?></td>
-                    <?php endforeach; ?>
-                </tr>
-                <tr>
-                    <td class="fw-bold">Тип накопичувача</td>
-                    <?php foreach ($products as $product): ?>
-                        <td><?php echo htmlspecialchars($product['storage_type']); ?></td>
-                    <?php endforeach; ?>
-                </tr>
-                <tr>
-                    <td class="fw-bold">Вага</td>
-                    <?php foreach ($products as $product): ?>
-                        <td><?php echo htmlspecialchars($product['device_weight']); ?> кг</td>
-                    <?php endforeach; ?>
-                </tr>
-                <tr>
-                    <td class="fw-bold">Наявність на складі</td>
-                    <?php foreach ($products as $product): ?>
-                        <td><?php echo htmlspecialchars($product['stock']); ?> шт.</td>
-                    <?php endforeach; ?>
-                </tr>
-                </tbody>
-            </table>
-        </div>
-    <?php endif; ?>
-
-    <div class="mt-3 text-center">
-        <a href="../../index.php" class="btn btn-secondary">Назад до каталогу</a>
-    </div>
-</div>
-
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-<script>
-    document.addEventListener('DOMContentLoaded', function() {
-        const removeButtons = document.querySelectorAll('.remove-compare');
-
-        removeButtons.forEach(button => {
-            button.addEventListener('click', function() {
-                try {
-                    const productId = this.getAttribute('data-product-id');
-
-                    let comparisonList;
-                    try {
-                        comparisonList = JSON.parse(localStorage.getItem('productComparison') || '[]');
-                    } catch (e) {
-                        console.error('Помилка читання localStorage:', e);
-                        comparisonList = [];
-                    }
-
-                    const updatedList = comparisonList.filter(id => id != productId);
-
-                    try {
-                        localStorage.setItem('productComparison', JSON.stringify(updatedList));
-                    } catch (e) {
-                        console.error('Помилка запису в localStorage:', e);
-                        alert('Не вдалося оновити список порівняння');
-                        return;
-                    }
-
-                    const currentProducts = new URLSearchParams(window.location.search).get('products');
-                    const newProducts = currentProducts.split(',')
-                        .filter(id => id != productId)
-                        .join(',');
-
-                    if (newProducts) {
-                        window.location.href = `compare.php?products=${newProducts}`;
-                    } else {
-                        window.location.href = 'index.php';
-                    }
-                } catch (e) {
-                    console.error('Критична помилка:', e);
-                    alert('Виникла непередбачена помилка');
-                }
-            });
-        });
-    });
-</script>
-</body>
-</html>
+require __DIR__ . '/../views/compare_view.php';

--- a/backend/views/compare_view.php
+++ b/backend/views/compare_view.php
@@ -1,0 +1,100 @@
+<?php
+
+?>
+<!DOCTYPE html>
+<html lang="uk">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Порівняння товарів – Ноутбук-Маркет</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.0/font/bootstrap-icons.css" rel="stylesheet">
+  <link href="/public/assets/css/compare.css" rel="stylesheet">
+</head>
+<body>
+
+<div class="container-fluid mt-5">
+  <h1 class="mb-4 text-center">Порівняння ноутбуків</h1>
+
+  <?php if (!empty($error_message)): ?>
+    <div class="alert alert-danger">
+      <?= htmlspecialchars($error_message) ?>
+      <p>Будь ласка, спробуйте пізніше або зверніться в підтримку.</p>
+    </div>
+  <?php elseif (empty($products)): ?>
+    <div class="alert alert-info">Немає товарів для порівняння</div>
+  <?php else: ?>
+    <div class="table-responsive">
+      <table class="table table-bordered table-striped table-hover table-compare">
+        <thead>
+          <tr>
+            <th>Параметр</th>
+            <?php foreach ($products as $product): ?>
+              <th>
+                <?= htmlspecialchars($product['name']) ?>
+                <button class="btn btn-sm btn-danger remove-compare" data-product-id="<?= htmlspecialchars($product['id']) ?>">
+                  <i class="bi bi-trash"></i>
+                </button>
+              </th>
+            <?php endforeach; ?>
+          </tr>
+          <tr>
+            <th>Зображення</th>
+            <?php foreach ($products as $product): ?>
+              <th>
+                <?php if (!empty($product['image_filename'])): ?>
+                  <img src="<?= htmlspecialchars($product['image_filename']) ?>"
+                       alt="<?= htmlspecialchars($product['name']) ?>"
+                       class="img-fluid" style="max-height:200px;">
+                <?php else: ?>
+                  <p>Відсутнє</p>
+                <?php endif; ?>
+              </th>
+            <?php endforeach; ?>
+          </tr>
+        </thead>
+        <tbody>
+          <?php
+         
+          $fields = [
+            ['label' => 'Ціна',       'key' => 'price',          'suffix' => ' грн'],
+            ['label' => 'Опис',       'key' => 'description',    'suffix' => ''],
+            ['label' => 'Екран',      'key' => 'screen_size',    'suffix' => ' дюймів'],
+            ['label' => 'Відеокарта', 'key' => 'video_card_type','suffix' => ''],
+            ['label' => 'Накопичувач','key' => 'storage_type',   'suffix' => ''],
+            ['label' => 'Вага',       'key' => 'device_weight',  'suffix' => ' кг'],
+            ['label' => 'Наявність',  'key' => 'stock',          'suffix' => ' шт'],
+          ];
+          foreach ($fields as $col): ?>
+            <tr>
+              <td class="fw-bold"><?= htmlspecialchars($col['label']) ?></td>
+              <?php foreach ($products as $product): ?>
+                <?php
+                $value = isset($product[$col['key']]) ? $product[$col['key']] : '';
+                if ($col['key'] === 'price' && $value !== '') {
+                    echo '<td>' . number_format($value, 2, '.', ' ') . $col['suffix'] . '</td>';
+                } else {
+                    $display = $value !== '' ? htmlspecialchars($value) . $col['suffix'] : '—';
+                    echo '<td>' . $display . '</td>';
+                }
+                ?>
+              <?php endforeach; ?>
+            </tr>
+          <?php endforeach; ?>
+        </tbody>
+      </table>
+    </div>
+  <?php endif; ?>
+
+  <div class="text-center mt-3">
+    <a href="/index.php" class="btn btn-secondary">Назад до каталогу</a>
+  </div>
+</div>
+
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" defer></script>
+
+
+<script src="/public/assets/js/compare.js" defer></script>
+</body>
+</html>

--- a/backend/views/product_view.php
+++ b/backend/views/product_view.php
@@ -1,0 +1,134 @@
+<?php
+
+?>
+<!DOCTYPE html>
+<html lang="uk">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title><?= htmlspecialchars($product['name']) ?> – Ноутбук-Маркет</title>
+
+
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+
+  <link href="/public/assets/css/style.css"   rel="stylesheet">
+  <link href="/public/assets/css/gallery.css" rel="stylesheet">
+  <link href="/public/assets/css/product.css" rel="stylesheet">
+  <script type="module" src="/public/assets/js/ui/imageHandlers.js" defer></script>
+</head>
+<body>
+  <?php if (!empty($_SESSION['error_message'])): ?>
+    <div class="alert alert-danger alert-dismissible fade show m-3" role="alert">
+      <?= htmlspecialchars($_SESSION['error_message']); unset($_SESSION['error_message']); ?>
+      <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+    </div>
+  <?php endif; ?>
+  <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+    <div class="container">
+      <a class="navbar-brand" href="/public/index.php">Ноутбук-Маркет</a>
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="navbarNav">
+        <ul class="navbar-nav me-auto">
+          <li class="nav-item"><a class="nav-link" href="/public/index.php">Головна</a></li>
+        </ul>
+        <ul class="navbar-nav">
+          <li class="nav-item">
+            <a class="nav-link" href="/public/orders/cart.php">
+              Кошик <span class="badge bg-primary"><?= count($_SESSION['cart'] ?? []) ?></span>
+            </a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </nav>
+
+
+  <div class="container my-5">
+    <div class="row gy-4">
+
+      <div class="col-md-6">
+        <img src="<?= htmlspecialchars($mainImage) ?>"
+             class="img-fluid rounded main-product-image"
+             alt="<?= htmlspecialchars($product['name']) ?>">
+
+        <?php if (count($images) > 1): ?>
+          <div class="image-thumbnails mt-3 d-flex flex-wrap">
+            <?php foreach ($images as $img): ?>
+              <img src="<?= htmlspecialchars($img) ?>"
+                   class="img-thumbnail me-2 mb-2"
+                   style="max-width:80px;"
+                   alt="thumbnail">
+            <?php endforeach; ?>
+          </div>
+        <?php endif; ?>
+      </div>
+      <div class="col-md-6">
+        <div class="mb-3"><?= renderProductBadges($product) ?></div>
+        <h1 class="h2"><?= htmlspecialchars($product['name']) ?></h1>
+        <p class="fs-3 fw-bold text-primary">
+          <?= formatProductPrice($product['price']) ?> грн
+        </p>
+        <p class="<?= getProductAvailabilityClass((int)$product['stock']) ?>">
+          <?= ((int)$product['stock'] > 0)
+              ? "В наявності: " . (int)$product['stock'] . " шт."
+              : "Немає в наявності" ?>
+        </p>
+
+        <?php if ((int)$product['stock'] > 0): ?>
+          <form action="/public/orders/cart.php" method="get" class="mb-4">
+            <input type="hidden" name="action" value="add">
+            <input type="hidden" name="id"     value="<?= $product['id'] ?>">
+
+            <div class="input-group mb-3" style="max-width: 140px;">
+              <button type="button" class="btn btn-outline-secondary" onclick="changeQuantity(-1)">−</button>
+              <input type="number"
+                     id="quantity" name="quantity"
+                     class="form-control text-center"
+                     min="1" max="<?= $product['stock'] ?>"
+                     value="1">
+              <button type="button" class="btn btn-outline-secondary" onclick="changeQuantity(1)">＋</button>
+            </div>
+
+            <div class="d-grid gap-2">
+              <button type="submit" class="btn btn-primary btn-lg">Додати в кошик</button>
+              <a href="/public/index.php" class="btn btn-outline-secondary">Повернутися до списку</a>
+            </div>
+          </form>
+        <?php else: ?>
+          <div class="d-grid gap-2 mb-4" style="max-width: 200px;">
+            <button class="btn btn-secondary btn-lg" disabled>Немає в наявності</button>
+            <a href="/public/index.php" class="btn btn-outline-secondary">Повернутися до списку</a>
+          </div>
+        <?php endif; ?>
+      </div>
+    </div>
+    <div class="row mt-5">
+      <div class="col">
+        <div class="card shadow-sm border-0">
+          <div class="card-header bg-primary text-white">Детальний опис</div>
+          <div class="card-body">
+            <p class="mb-0">
+              <?= nl2br(htmlspecialchars($product['full_description'] ?? 'Детальний опис відсутній')) ?>
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="image-zoom-container"></div>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" defer></script>
+  <script src="/public/assets/js/product.js" defer></script>
+  <script type="module" defer>
+    import { initImageZoom, changeMainImage } from '/public/assets/js/ui/imageHandlers.js';
+
+    document.addEventListener('DOMContentLoaded', () => {
+      initImageZoom();
+      document.querySelectorAll('.image-thumbnails img').forEach(img => {
+        img.onclick = () => changeMainImage(img);
+      });
+    });
+  </script>
+</body>
+</html>

--- a/public/assets/css/compare.css
+++ b/public/assets/css/compare.css
@@ -1,0 +1,12 @@
+.table-compare th,
+.table-compare td {
+  vertical-align: middle;
+  text-align: center;
+}
+.table-compare thead th {
+  background-color: #f8f9fa;
+}
+.remove-compare {
+  float: right;
+  font-size: 0.9rem;
+}

--- a/public/assets/css/product.css
+++ b/public/assets/css/product.css
@@ -1,0 +1,29 @@
+.image-thumbnails img {
+  transition: all 0.3s ease;
+  cursor: zoom-in;
+}
+.image-thumbnails img:hover {
+  opacity: 0.7;
+  transform: scale(1.05);
+}
+.main-product-image {
+  cursor: zoom-in;
+}
+.image-zoom-container {
+  position: fixed;
+  top: 50%;
+  right: 20px;
+  transform: translateY(-50%);
+  width: 300px;
+  height: 300px;
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  border: 2px solid #007bff;
+  border-radius: 10px;
+  box-shadow: 0 4px 6px rgba(0,0,0,0.1);
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  z-index: 1000;
+  pointer-events: none;
+}

--- a/public/assets/js/compare.js
+++ b/public/assets/js/compare.js
@@ -1,0 +1,40 @@
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.remove-compare').forEach(btn => {
+    btn.addEventListener('click', () => {
+     
+      const id = btn.dataset.productId;
+      let list;
+      try {
+        list = JSON.parse(localStorage.getItem('productComparison') || '[]');
+      } catch (e) {
+        console.error('Помилка читання списку порівняння:', e);
+        list = [];
+      }
+
+      
+      const updatedList = list.filter(x => x != id);
+
+      try {
+        localStorage.setItem('productComparison', JSON.stringify(updatedList));
+      } catch (e) {
+        console.error('Помилка запису списку порівняння:', e);
+        alert('Не вдалося оновити список порівняння');
+        return;
+      }
+
+     
+      const params = new URLSearchParams(window.location.search);
+      const newProducts = params.get('products')
+        .split(',')
+        .filter(x => x != id)
+        .join(',');
+
+      
+      const target = newProducts
+        ? `/backend/utils/compare.php?products=${newProducts}`
+        : '/index.php';
+      window.location.href = target;
+    });
+  });
+});

--- a/public/assets/js/product.js
+++ b/public/assets/js/product.js
@@ -1,0 +1,36 @@
+function changeMainImage(thumbnail) {
+  document.querySelector('.main-product-image').src = thumbnail.src;
+}
+
+
+function changeQuantity(delta) {
+  const input = document.getElementById('quantity');
+  let val = parseInt(input.value, 10) || 1;
+  val += delta;
+  if (val >= parseInt(input.min, 10) && val <= parseInt(input.max, 10)) {
+    input.value = val;
+  }
+}
+
+
+document.addEventListener('DOMContentLoaded', () => {
+  const zoom = document.querySelector('.image-zoom-container');
+  const mainImage = document.querySelector('.main-product-image');
+
+
+  mainImage.addEventListener('mouseenter', () => {
+    zoom.style.backgroundImage = `url(${mainImage.src})`;
+    zoom.style.opacity = '1';
+  });
+  mainImage.addEventListener('mouseleave', () => {
+    zoom.style.opacity = '0';
+  });
+
+
+  mainImage.addEventListener('mousemove', e => {
+    const { left, top, width, height } = mainImage.getBoundingClientRect();
+    const x = ((e.clientX - left) / width) * 100;
+    const y = ((e.clientY - top) / height) * 100;
+    zoom.style.backgroundPosition = `${x}% ${y}%`;
+  });
+});


### PR DESCRIPTION
Що зроблено:
Виніс утиліти в backend/helpers.php (redirect, форматування ціни, класи, бейджі)
Сторінку товару розбив на:
Контролер backend/products/product.php
Шаблон backend/views/product_view.php
Стилі public/assets/css/product.css
JS public/assets/js/product.js + public/assets/js/ui/imageHandlers.js
Функціонал порівняння розділив на:
Контролер backend/utils/compare.php
Шаблон backend/views/compare_view.php
Стилі public/assets/css/compare.css
JS public/assets/js/compare.js
Тепер логіка, HTML, CSS і JS лежать окремо й легко підтримуються.